### PR TITLE
Handle properly possible errors during the startup of the microservice and its bundled web server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype. Version 0.2.0
+# Customers API Lite microservice prototype. Version 0.2.5
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype. Version 0.2.0
+# Customers API Lite microservice prototype. Version 0.2.5
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ ./gradlew -q bootRun; echo $?
 **Run** the microservice using its all-in-one JAR bundle, built previously by the `build` or `all` targets:
 
 ```
-$ java -jar build/libs/customers-api-lite-0.2.0.jar; echo $?
+$ java -jar build/libs/customers-api-lite-0.2.5.jar; echo $?
 ...
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 /*
  * build.gradle
  * ============================================================================
- * Customers API Lite microservice prototype. Version 0.2.0
+ * Customers API Lite microservice prototype. Version 0.2.5
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing a special Customers API prototype
@@ -71,7 +71,7 @@ java {
 }
 
 group       = 'com.customers.proto'
-version     = '0.2.0'
+version     = '0.2.5'
 description = 'Customers API Lite microservice prototype.'
 
 // vim:set nu et ts=4 sw=4:

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype. Version 0.2.0
+-- Customers API Lite microservice prototype. Version 0.2.5
 -- ============================================================================
 -- A Spring Boot-based application, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype. Version 0.2.0
+-- Customers API Lite microservice prototype. Version 0.2.5
 -- ============================================================================
 -- A Spring Boot-based application, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype. Version 0.2.0
+-- Customers API Lite microservice prototype. Version 0.2.5
 -- ============================================================================
 -- A Spring Boot-based application, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype. Version 0.2.0
+-- Customers API Lite microservice prototype. Version 0.2.5
 -- ============================================================================
 -- A Spring Boot-based application, designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 /*
  * settings.gradle
  * ============================================================================
- * Customers API Lite microservice prototype. Version 0.2.0
+ * Customers API Lite microservice prototype. Version 0.2.5
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing a special Customers API prototype

--- a/src/main/java/com/customers/proto/liteapi/CustomersApiLiteApp.java
+++ b/src/main/java/com/customers/proto/liteapi/CustomersApiLiteApp.java
@@ -50,6 +50,9 @@ public class CustomersApiLiteApp implements DisposableBean {
         cfg.setIdent(null); cfg.setFacility(SyslogIF.FACILITY_DAEMON);
         s = new UnixSyslog(); s.initialize (SyslogIF.UNIX_SYSLOG,cfg);
 
+        // Getting the port number used to run the bundled web server.
+        var server_port = get_server_port();
+
         ConfigurableApplicationContext ctx = null;
 
         // Trying to start up the bundled web server.
@@ -84,9 +87,6 @@ public class CustomersApiLiteApp implements DisposableBean {
         i_cont   = new SimpleJdbcInsert[2];
         i_cont[0]= new SimpleJdbcInsert(ds).withTableName(DB_T_CONTACT_PHONES);
         i_cont[1]= new SimpleJdbcInsert(ds).withTableName(DB_T_CONTACT_EMAILS);
-
-        // Getting the port number used to run the bundled web server.
-        var server_port = env.getProperty(SERVER_PORT);
 
         l.info(MSG_SERVER_STARTED + server_port);
         s.info(MSG_SERVER_STARTED + server_port);

--- a/src/main/java/com/customers/proto/liteapi/CustomersApiLiteApp.java
+++ b/src/main/java/com/customers/proto/liteapi/CustomersApiLiteApp.java
@@ -1,7 +1,7 @@
 /*
  * src/main/java/com/customers/proto/liteapi/CustomersApiLiteApp.java
  * ============================================================================
- * Customers API Lite microservice prototype. Version 0.2.0
+ * Customers API Lite microservice prototype. Version 0.2.5
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing a special Customers API prototype
@@ -33,7 +33,7 @@ import static com.customers.proto.liteapi.CustomersApiLiteHelper.*;
 /**
  * The startup class of the microservice.
  *
- * @version 0.2.0
+ * @version 0.2.5
  * @since   0.0.1
  */
 @SpringBootApplication

--- a/src/main/java/com/customers/proto/liteapi/CustomersApiLiteController.java
+++ b/src/main/java/com/customers/proto/liteapi/CustomersApiLiteController.java
@@ -1,7 +1,7 @@
 /*
  * src/main/java/com/customers/proto/liteapi/CustomersApiLiteController.java
  * ============================================================================
- * Customers API Lite microservice prototype. Version 0.2.0
+ * Customers API Lite microservice prototype. Version 0.2.5
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing a special Customers API prototype
@@ -38,7 +38,7 @@ import static com.customers.proto.liteapi.CustomersApiLiteModel.*;
  * <br />
  * <br />&lt;HTTP request method&gt; <code>/v1/customers</code>.
  *
- * @version 0.2.0
+ * @version 0.2.5
  * @since   0.1.0
  */
 @RestController

--- a/src/main/java/com/customers/proto/liteapi/CustomersApiLiteEntityContact.java
+++ b/src/main/java/com/customers/proto/liteapi/CustomersApiLiteEntityContact.java
@@ -1,7 +1,7 @@
 /*
  * src/main/java/com/customers/proto/liteapi/CustomersApiLiteEntityContact.java
  * ============================================================================
- * Customers API Lite microservice prototype. Version 0.2.0
+ * Customers API Lite microservice prototype. Version 0.2.5
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing a special Customers API prototype
@@ -15,7 +15,7 @@ package com.customers.proto.liteapi;
 /**
  * The POJO representation of the Contact entity, returning in the response.
  *
- * @version 0.2.0
+ * @version 0.2.5
  * @since   0.1.5
  */
 public class CustomersApiLiteEntityContact {

--- a/src/main/java/com/customers/proto/liteapi/CustomersApiLiteEntityCustomer.java
+++ b/src/main/java/com/customers/proto/liteapi/CustomersApiLiteEntityCustomer.java
@@ -1,7 +1,7 @@
 /*
  *src/main/java/com/customers/proto/liteapi/CustomersApiLiteEntityCustomer.java
  * ============================================================================
- * Customers API Lite microservice prototype. Version 0.2.0
+ * Customers API Lite microservice prototype. Version 0.2.5
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing a special Customers API prototype
@@ -15,7 +15,7 @@ package com.customers.proto.liteapi;
 /**
  * The POJO representation of the Customer entity, returning in the response.
  *
- * @version 0.2.0
+ * @version 0.2.5
  * @since   0.1.1
  */
 public class CustomersApiLiteEntityCustomer {

--- a/src/main/java/com/customers/proto/liteapi/CustomersApiLiteHelper.java
+++ b/src/main/java/com/customers/proto/liteapi/CustomersApiLiteHelper.java
@@ -1,7 +1,7 @@
 /*
  * src/main/java/com/customers/proto/liteapi/CustomersApiLiteHelper.java
  * ============================================================================
- * Customers API Lite microservice prototype. Version 0.2.0
+ * Customers API Lite microservice prototype. Version 0.2.5
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing a special Customers API prototype
@@ -26,7 +26,7 @@ import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 /**
  * The helper class for the microservice.
  *
- * @version 0.2.0
+ * @version 0.2.5
  * @since   0.0.1
  */
 public class CustomersApiLiteHelper {

--- a/src/main/java/com/customers/proto/liteapi/CustomersApiLiteHelper.java
+++ b/src/main/java/com/customers/proto/liteapi/CustomersApiLiteHelper.java
@@ -44,8 +44,8 @@ public class CustomersApiLiteHelper {
     // Common error messages.
     public static final String ERR_PORT_VALID_MUST_BE_POSITIVE_INT
         = "Valid server port must be a positive integer value, "
-        + "in the range 1024 .. 49151. The default value of 8080 "
-        + "will be used instead.";
+        + "in the range 1024 .. 49151. Please set the correct "
+        + "server port number in application properties.";
     public static final String ERR_APP_PROPS_UNABLE_TO_GET
         = "Unable to get application properties.";
     public static final String ERR_CANNOT_START_SERVER
@@ -145,30 +145,24 @@ public class CustomersApiLiteHelper {
         var server_port_ = _get_props().getProperty(SERVER_PORT);
         var server_port  = 0;
 
-        l.debug(O_BRACKET + server_port_ + C_BRACKET);
-
         try { server_port = Integer.parseInt(server_port_); }
         catch (NumberFormatException e) { /* Using the last `else' block. */ }
 
-        l.debug(O_BRACKET + server_port + C_BRACKET);
-
         if (server_port != 0) {
-            l.debug(O_BRACKET + "---1---" + C_BRACKET);
-
             if ((server_port >= MIN_PORT) && (server_port <= MAX_PORT)) {
-                l.debug(O_BRACKET + "---2---" + C_BRACKET);
-
                 return server_port;
             } else {
-                l.debug(O_BRACKET + "---3---" + C_BRACKET);
+                l.error(ERR_PORT_VALID_MUST_BE_POSITIVE_INT);
 
-                l.error(ERR_PORT_VALID_MUST_BE_POSITIVE_INT); return DEF_PORT;
+                System.exit(EXIT_FAILURE);
             }
         } else {
-            l.debug(O_BRACKET + "---4---" + C_BRACKET);
+            l.error(ERR_PORT_VALID_MUST_BE_POSITIVE_INT);
 
-            l.error(ERR_PORT_VALID_MUST_BE_POSITIVE_INT); return DEF_PORT;
+            System.exit(EXIT_FAILURE);
         }
+
+        return DEF_PORT; // <== For the sake of suppressing compilation errors.
     }
 
     // Helper method. Used to get the application properties object.

--- a/src/main/java/com/customers/proto/liteapi/CustomersApiLiteModel.java
+++ b/src/main/java/com/customers/proto/liteapi/CustomersApiLiteModel.java
@@ -1,7 +1,7 @@
 /*
  * src/main/java/com/customers/proto/liteapi/CustomersApiLiteModel.java
  * ============================================================================
- * Customers API Lite microservice prototype. Version 0.2.0
+ * Customers API Lite microservice prototype. Version 0.2.5
  * ============================================================================
  * A Spring Boot-based application, designed and intended to be run
  * as a microservice, implementing a special Customers API prototype
@@ -15,7 +15,7 @@ package com.customers.proto.liteapi;
 /**
  * The model class of the microservice.
  *
- * @version 0.2.0
+ * @version 0.2.5
  * @since   0.1.1
  */
 public class CustomersApiLiteModel {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 #
 # src/main/resources/application.properties
 # =============================================================================
-# Customers API Lite microservice prototype. Version 0.2.0
+# Customers API Lite microservice prototype. Version 0.2.5
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # src/main/resources/log4j.properties
 # =============================================================================
-# Customers API Lite microservice prototype. Version 0.2.0
+# Customers API Lite microservice prototype. Version 0.2.5
 # =============================================================================
 # A Spring Boot-based application, designed and intended to be run
 # as a microservice, implementing a special Customers API prototype


### PR DESCRIPTION
- Adding constants: minimum / maximum / default **server port numbers**, the **application properties filename**, and an **error message** when the application _is unable to get_ application properties.
- Adding a convenience method to **retrieve the port number used to run the server**, from application properties.
- Adding a helper method that is used to **get the application properties** object.
- Getting the port number used to run the bundled web server using the convenience and safe method for that &mdash; _to avoid trying to bind to forbidden application ports_ (outside of the `1024 .. 49151` range).
- Stopping the application immediately with failing exit status _when the server port number is not valid_, emitting the appropriate error message.
- Bumping version number to **0.2.5**.